### PR TITLE
only allow plusplus operator in for loops

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 module.exports = {
   "env": {
     "browser": true,
-    "es6": true,
     "es2017": true,
     "node": true
   },
@@ -157,7 +156,7 @@ module.exports = {
     "no-octal-escape": "error",
     "no-param-reassign": "off",
     "no-path-concat": "error",
-    "no-plusplus": "off",
+    "no-plusplus": ["error", { "allowForLoopAfterthoughts": true }],
     "no-process-env": "off",
     "no-process-exit": "error",
     "no-proto": "error",


### PR DESCRIPTION
in microdraw it is set as error everywhere but here it is set to off. a good compromise could be to allow it only in for loops